### PR TITLE
Display missions - Lists Render

### DIFF
--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,14 +1,19 @@
 /* eslint-disable camelcase */
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { getMissions } from '../redux/missions/missions';
+import { getMissions, joinMissionAction } from '../redux/missions/missions';
 import './missions.css';
 
-function Missions() {
+let loadOnce = false;
+
+const Missions = () => {
   const dispatch = useDispatch();
   const missions = useSelector((state) => state.missionsReducer);
   useEffect(() => {
-    dispatch(getMissions());
+    if (!loadOnce) {
+      dispatch(getMissions());
+      loadOnce = true;
+    }
   }, [dispatch]);
 
   return (
@@ -16,27 +21,61 @@ function Missions() {
       <table className="Missions__table">
         <thead>
           <tr>
-            <th>Mission</th>
-            <th>Description</th>
-            <th>Status</th>
-            <th>Join</th>
+            <th>
+              <h1>Mission</h1>
+            </th>
+            <th>
+              <h1>Description</h1>
+            </th>
+            <th>
+              <h1>Status</h1>
+            </th>
+            <th>
+              <h1>Join</h1>
+            </th>
           </tr>
         </thead>
-        {
-          missions.map(({
-            mission_id, mission_name, description, reserved = false,
-          }) => (
-            <tr key={mission_id}>
-              <td className="Missions__name"><h1>{ mission_name }</h1></td>
-              <td className="Missions__description"><p>{ description }</p></td>
-              <td>{ reserved ? (<span className="badge badge--primary">ACTIVE MEMBER</span>) : (<span className="badge badge--secondary">NOT A MEMBER</span>) }</td>
-              <td>{ reserved ? (<button type="button" className="app-btn-danger">Leave Mission</button>) : (<button type="button" className="app-btn-ghost">Join Mission</button>) }</td>
-            </tr>
-          ))
-        }
+        {missions.map(({
+          id, name, description, reserved,
+        }) => (
+          <tr key={id}>
+            <td className="Missions__name">
+              <h1>{name}</h1>
+            </td>
+            <td className="Missions__description">
+              <p>{description}</p>
+            </td>
+            <td>
+              {reserved ? (
+                <span className="badge badge--primary">ACTIVE MEMBER</span>
+              ) : (
+                <span className="badge badge--secondary">NOT A MEMBER</span>
+              )}
+            </td>
+            <td>
+              {reserved ? (
+                <button
+                  type="button"
+                  onClick={() => dispatch(joinMissionAction(id))}
+                  className="app-btn-danger"
+                >
+                  Leave Mission
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => dispatch(joinMissionAction(id))}
+                  className="app-btn-ghost"
+                >
+                  Join Mission
+                </button>
+              )}
+            </td>
+          </tr>
+        ))}
       </table>
     </div>
   );
-}
+};
 
 export default Missions;

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,15 +1,27 @@
 import fetchMissions from '../../apiServices/getMissionsApi';
 
 const MISSIONS = 'redux/actions/get_missions';
+const JOIN_MISSION = 'redux/actions/join_mission';
 
-const missions = (missions) => ({
+const getMissionsAction = (missions) => ({
   type: MISSIONS,
   payload: missions,
 });
 
+export const joinMissionAction = (missionID) => ({
+  type: JOIN_MISSION,
+  payload: missionID,
+});
+
 export const getMissions = () => (dispach) => {
-  fetchMissions().then((mission) => {
-    dispach(missions(mission));
+  fetchMissions().then((data) => {
+    const missions = data.map((mission) => ({
+      id: mission.mission_id,
+      name: mission.mission_name,
+      description: mission.description,
+      reserved: false,
+    }));
+    dispach(getMissionsAction(missions));
   });
 };
 
@@ -17,6 +29,10 @@ const missionsReducer = (state = [], action) => {
   switch (action.type) {
     case MISSIONS:
       return action.payload;
+    case JOIN_MISSION:
+      return state.map((mission) => (mission.id === action.payload
+        ? { ...mission, reserved: !mission.reserved }
+        : { ...mission }));
     default:
       return state;
   }


### PR DESCRIPTION
Hello @NabilHY,

In this milestone, I have implemented the join/leave actions and the switch badge for missions.
- Use useSelector() Redux Hook to select the state slices and render lists of missions in corresponding routes. i.e.:
-  Add "Join Missions" function.
- Add  "Leave Missions" function.
- Missions that the user has joined already should show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).